### PR TITLE
Add inheritAttrs: false to the vue component

### DIFF
--- a/src/vue3-simple-typeahead.vue
+++ b/src/vue3-simple-typeahead.vue
@@ -42,6 +42,7 @@
 	export default /*#__PURE__*/ defineComponent({
 		name: 'Vue3SimpleTypeahead',
 		emits: ['onInput', 'onFocus', 'onBlur', 'selectItem'],
+		inheritAttrs: false,
 		props: {
 			id: {
 				type: String,


### PR DESCRIPTION
Use inheritAttrs to prevent fallthrough attributes to appear on both the input and the wrapper.