### PR TITLE
Added minItemLength prop and behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ It would fallthrough to the input control of the component:
 | [`items`](#items)                   | Array (Required) |                            | List of objects or strings with the elements for suggestions                            |
 | [`defaultItem`](#defaultItem)       | Any              |                            | Default item to be selected                                                             |
 | [`minInputLength`](#minInputLength) | Number           | 2                          | Minimum input length for the suggestion length to appear, the prop value has to be >= 0 |
+| [`minItemLength`](#minItemLength)   | Number           | 0                          | Minimum number of items that need to be visible for suggestions to appear, the prop value has to be >= 0 |
 | [`itemProjection`](#itemProjection) | Function: String | `(item) => {return item;}` | Projection function to map the items to a string value for search and display           |
 | [`selectOnTab`](#selectOnTab)       | Boolean          | `true`                     | Enable/Disable item selection on <kbd>TAB</kbd>                                         |
 

--- a/src/vue3-simple-typeahead.vue
+++ b/src/vue3-simple-typeahead.vue
@@ -73,6 +73,13 @@
 					return prop >= 0;
 				},
 			},
+			minItemLength: {
+				type: Number,
+				default: 0,
+				validator: (prop) => {
+					return prop >= 0;
+				},
+			},
 			selectOnTab: {
 				type: Boolean,
 				default: true,
@@ -185,7 +192,7 @@
 				return this.items.filter((item) => this.itemProjection(item).match(regexp));
 			},
 			isListVisible() {
-				return this.isInputFocused && this.input.length >= this.minInputLength && this.filteredItems.length;
+				return this.isInputFocused && this.input.length >= this.minInputLength && this.filteredItems.length > this.minItemLength;
 			},
 			currentSelection() {
 				return this.isListVisible && this.currentSelectionIndex < this.filteredItems.length ? this.filteredItems[this.currentSelectionIndex] : undefined;


### PR DESCRIPTION
The minItemLength determines how many items must remain before the suggestion window is hidden. The existing code only hides the suggestion list once no items match, but I would like the option to hide the list when only one item matches. This prop enables this, but doesn't change the existing default behaviour.